### PR TITLE
Return txid from sign

### DIFF
--- a/account.go
+++ b/account.go
@@ -238,7 +238,7 @@ func (a *Account) SendXLM(from SeedStr, to AddressStr, amount string) (ledger in
 
 // paymentXLM creates a payment transaction from 'from' to 'to' for 'amount' lumens.
 func (a *Account) paymentXLM(from SeedStr, to AddressStr, amount string) (ledger int32, txid string, err error) {
-	_, signed, err := a.PaymentXLMTransaction(from, to, amount, client)
+	_, signed, _, err := a.PaymentXLMTransaction(from, to, amount, client)
 	if err != nil {
 		return 0, "", err
 	}
@@ -247,7 +247,8 @@ func (a *Account) paymentXLM(from SeedStr, to AddressStr, amount string) (ledger
 }
 
 // PaymentXLMTransaction creates a signed transaction to send a payment from 'from' to 'to' for 'amount' lumens.
-func (a *Account) PaymentXLMTransaction(from SeedStr, to AddressStr, amount string, seqnoProvider build.SequenceProvider) (seqno uint64, signed string, err error) {
+func (a *Account) PaymentXLMTransaction(from SeedStr, to AddressStr, amount string,
+	seqnoProvider build.SequenceProvider) (seqno uint64, signed, txHashHex string, err error) {
 	tx, err := build.Transaction(
 		build.SourceAccount{AddressOrSeed: from.SecureNoLogString()},
 		network,
@@ -259,7 +260,7 @@ func (a *Account) PaymentXLMTransaction(from SeedStr, to AddressStr, amount stri
 		build.MemoText{Value: "via keybase"},
 	)
 	if err != nil {
-		return 0, "", err
+		return 0, "", "", err
 	}
 
 	return a.sign(from, tx)
@@ -267,7 +268,7 @@ func (a *Account) PaymentXLMTransaction(from SeedStr, to AddressStr, amount stri
 
 // createAccountXLM funds an new account 'to' from 'from' with a starting balance of 'amount'.
 func (a *Account) createAccountXLM(from SeedStr, to AddressStr, amount string) (ledger int32, txid string, err error) {
-	_, signed, err := a.CreateAccountXLMTransaction(from, to, amount, client)
+	_, signed, _, err := a.CreateAccountXLMTransaction(from, to, amount, client)
 	if err != nil {
 		return 0, "", err
 	}
@@ -277,7 +278,8 @@ func (a *Account) createAccountXLM(from SeedStr, to AddressStr, amount string) (
 
 // CreateAccountXLMTransaction creates a signed transaction to fund an new account 'to' from 'from'
 // with a starting balance of 'amount'.
-func (a *Account) CreateAccountXLMTransaction(from SeedStr, to AddressStr, amount string, seqnoProvider build.SequenceProvider) (seqno uint64, signed string, err error) {
+func (a *Account) CreateAccountXLMTransaction(from SeedStr, to AddressStr, amount string,
+	seqnoProvider build.SequenceProvider) (seqno uint64, signed string, txHashHex string, err error) {
 	tx, err := build.Transaction(
 		build.SourceAccount{AddressOrSeed: from.SecureNoLogString()},
 		network,
@@ -289,22 +291,26 @@ func (a *Account) CreateAccountXLMTransaction(from SeedStr, to AddressStr, amoun
 		build.MemoText{Value: "via keybase"},
 	)
 	if err != nil {
-		return 0, "", err
+		return 0, "", "", err
 	}
 
 	return a.sign(from, tx)
 }
 
 // sign signs and base64-encodes a transaction.
-func (a *Account) sign(from SeedStr, tx *build.TransactionBuilder) (seqno uint64, signed string, err error) {
+func (a *Account) sign(from SeedStr, tx *build.TransactionBuilder) (seqno uint64, signed, txHashHex string, err error) {
 	txe, err := tx.Sign(from.SecureNoLogString())
 	if err != nil {
-		return 0, "", err
+		return 0, "", "", err
 	}
 
 	seqno = uint64(txe.E.Tx.SeqNum)
 	signed, err = txe.Base64()
-	return seqno, signed, err
+	if err != nil {
+		return 0, "", "", err
+	}
+	txHashHex, err = tx.HashHex()
+	return seqno, signed, txHashHex, err
 }
 
 // Submit submits a signed transaction to horizon.

--- a/account.go
+++ b/account.go
@@ -122,7 +122,7 @@ func AccountSeqno(address AddressStr) (uint64, error) {
 }
 
 // RecentPayments returns the account's recent payments.
-// This is a summary of any recent payment transactions (payment or create_account).
+// This is a summary of any recent payment transactions (payment, create_account, or account_merge).
 // It does not contain as much information as RecentTransactions.
 // It is faster as it is only one request to horizon.
 func (a *Account) RecentPayments() ([]horizon.Payment, error) {


### PR DESCRIPTION
I'd like to include the txid in encrypted notes. So that clients can assert a note matches a tx. I bet this is the right value, and will check before merging.

Afaik the txid is the hash of the tx, so it is known even before signing.