### PR TITLE
Add hashtx

### DIFF
--- a/account.go
+++ b/account.go
@@ -10,6 +10,8 @@ import (
 	samount "github.com/stellar/go/amount"
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
+	snetwork "github.com/stellar/go/network"
+	"github.com/stellar/go/xdr"
 )
 
 var client = horizon.DefaultPublicNetClient
@@ -212,6 +214,15 @@ func TxPayments(txID string) ([]horizon.Payment, error) {
 		return nil, err
 	}
 	return page.Embedded.Records, nil
+}
+
+// HashTx returns the hex transaction ID using the active network passphrase.
+func HashTx(tx xdr.Transaction) (string, error) {
+	bs, err := snetwork.HashTransaction(&tx, network.Passphrase)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bs[:]), nil
 }
 
 // CheckTxID validates and canonicalizes a transaction ID

--- a/account_test.go
+++ b/account_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keybase/stellarnet/testclient"
 	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -204,4 +205,14 @@ func TestScenario(t *testing.T) {
 	_, err = TxPayments(bobTx[0].Internal.ID[:5])
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error decoding transaction ID")
+
+	txid2, err := CheckTxID(bobTx[0].Internal.ID)
+	require.NoError(t, err)
+	require.Equal(t, bobTx[0].Internal.ID, txid)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(bobTx[0].Internal.EnvelopeXdr, &tx)
+	require.NoError(t, err)
+	txid3, err := HashTx(tx.Tx)
+	require.Equal(t, txid2, txid3)
 }


### PR DESCRIPTION
`stellarnet` has package state including what network is being used. Transaction IDs include the active network (woe is me) so use whatever `stellarnet` is using. Need this for txIDPrecalc on stellard to match up when running tests.