### PR TITLE
Add lock for globals

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -9,7 +9,7 @@ import (
 // HorizonRoot returns the root information from the horizon
 // server.
 func HorizonRoot() (horizon.Root, error) {
-	return client.Root()
+	return Client().Root()
 }
 
 // Ping returns a formatted string of info about the horizon server


### PR DESCRIPTION
Little bit of defense against torn reads. Doesn't change the fact that if you set anything concurrently with creating a transaction, it might get signed and posted for different networks.