### PR TITLE
Split ErrAccountNotFound into ErrSourceAccountNotFound and ErrDestinationAccountNotFound

### DIFF
--- a/account.go
+++ b/account.go
@@ -208,7 +208,7 @@ func IsMasterKeyActive(accountID AddressStr) (bool, error) {
 	a := NewAccount(accountID)
 	err := a.load()
 	if err != nil {
-		if err == ErrAccountNotFound {
+		if err == ErrSourceAccountNotFound {
 			// Accounts with no entries have active master keys.
 			return true, nil
 		}
@@ -381,7 +381,7 @@ func SendXLM(from SeedStr, to AddressStr, amount, memoText string) (ledger int32
 	ledger, txid, err = paymentXLM(from, to, amount, memoText)
 
 	if err != nil {
-		if err != ErrAccountNotFound {
+		if err != ErrDestinationAccountNotFound {
 			return 0, "", err
 		}
 
@@ -577,12 +577,12 @@ func errMap(err error) error {
 	xerr := errors.Cause(err)
 
 	if isOpNoDestination(xerr) {
-		return ErrAccountNotFound
+		return ErrDestinationAccountNotFound
 	}
 
 	if herr, ok := xerr.(*horizon.Error); ok {
 		if herr.Problem.Status == 404 {
-			return ErrAccountNotFound
+			return ErrSourceAccountNotFound
 		}
 	}
 

--- a/account_test.go
+++ b/account_test.go
@@ -73,13 +73,13 @@ func TestScenario(t *testing.T) {
 	t.Log("alice key pair not an account yet")
 	acctAlice := NewAccount(addressStr(t, helper.Alice))
 	_, err := acctAlice.BalanceXLM()
-	if err != ErrAccountNotFound {
-		t.Fatalf("error: %q, expected %q (ErrAccountNotFound)", err, ErrAccountNotFound)
+	if err != ErrSourceAccountNotFound {
+		t.Fatalf("error: %q, expected %q (ErrSourceAccountNotFound)", err, ErrSourceAccountNotFound)
 	}
 
 	_, err = AccountSeqno(addressStr(t, helper.Alice))
-	if err != ErrAccountNotFound {
-		t.Fatalf("error: %q, expected %q (ErrAccountNotFound)", err, ErrAccountNotFound)
+	if err != ErrSourceAccountNotFound {
+		t.Fatalf("error: %q, expected %q (ErrSourceAccountNotFound)", err, ErrSourceAccountNotFound)
 	}
 
 	active, err := IsMasterKeyActive(addressStr(t, helper.Alice))
@@ -256,7 +256,7 @@ func TestScenario(t *testing.T) {
 	t.Log("bob's account has been merged away")
 	_, err = acctBob.BalanceXLM()
 	require.Error(t, err)
-	require.Equal(t, ErrAccountNotFound, err)
+	require.Equal(t, ErrSourceAccountNotFound, err)
 
 	t.Log("alice got bob's balance")
 	balance, err = acctAlice.BalanceXLM()

--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,12 @@ import "errors"
 // ErrAccountNotFound is returned if there is no stellar account for an address.
 var ErrAccountNotFound = errors.New("account not found")
 
+// ErrSourceAccountNotFound is returned if there is no stellar account for a source account address.
+var ErrSourceAccountNotFound = errors.New("source account not found")
+
+// ErrDestinationAccountNotFound is returned if there is no stellar account for a destinationaccount address.
+var ErrDestinationAccountNotFound = errors.New("destination account not found")
+
 // ErrAddressNotSeed is returned when the string is a stellar address, not a seed.
 var ErrAddressNotSeed = errors.New("string provided is an address not a seed")
 

--- a/errors.go
+++ b/errors.go
@@ -2,9 +2,6 @@ package stellarnet
 
 import "errors"
 
-// ErrAccountNotFound is returned if there is no stellar account for an address.
-var ErrAccountNotFound = errors.New("account not found")
-
 // ErrSourceAccountNotFound is returned if there is no stellar account for a source account address.
 var ErrSourceAccountNotFound = errors.New("source account not found")
 


### PR DESCRIPTION
This will make it easier for stellard to return better error messages for humans.