### PR TITLE
consolidate stellar amount methods and rename for descriptiveness

### DIFF
--- a/account.go
+++ b/account.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	samount "github.com/stellar/go/amount"
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
 	snetwork "github.com/stellar/go/network"
@@ -160,7 +159,7 @@ func (a *Account) availableBalanceXLMLoaded() (string, error) {
 // be sent to another account (leaving enough XLM in the sender's
 // account to maintain the minimum balance).
 func AvailableBalance(balance string, subentryCount int) (string, error) {
-	balanceInt, err := samount.ParseInt64(balance)
+	balanceInt, err := ParseStellarAmount(balance)
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +171,7 @@ func AvailableBalance(balance string, subentryCount int) (string, error) {
 		available = 0
 	}
 
-	return samount.StringFromInt64(available), nil
+	return StringFromStellarAmount(available), nil
 }
 
 // AccountDetails contains basic details about a stellar account.
@@ -421,7 +420,7 @@ func SendXLM(from SeedStr, to AddressStr, amount, memoText string) (ledger int32
 		return 0, "", errors.New("public memo is too long")
 	}
 	// this is checked in build.Transaction, but can't hurt to break out early
-	if _, err = samount.Parse(amount); err != nil {
+	if _, err = ParseStellarAmount(amount); err != nil {
 		return 0, "", err
 	}
 

--- a/amounts_test.go
+++ b/amounts_test.go
@@ -158,7 +158,7 @@ func TestDecimalStrictRegex(t *testing.T) {
 	}
 }
 
-func TestParseDecimalStrict(t *testing.T) {
+func TestParseAmount(t *testing.T) {
 	for i, unit := range decimalUnits {
 		for _, neg := range []bool{false, true} {
 			t.Logf("%v: %#v", i, unit)
@@ -166,7 +166,7 @@ func TestParseDecimalStrict(t *testing.T) {
 			if neg {
 				s = "-" + s
 			}
-			v, err := ParseDecimalStrict(s)
+			v, err := ParseAmount(s)
 			t.Logf("-> (%v, %v)", v, err)
 			require.Equal(t, unit.ok, err == nil, "parsed without error")
 			if unit.ok {


### PR DESCRIPTION
* rename ParseDecimalStrict to ParseAmount
* add ParseStellarAmount which explicitly uses ParseAmount and adds the check for significant digits. You may recognize this behavior from such functions as `stellar/amount#ParseInt64` which has the behavioral weirdness in our version (not on stellar/master) of accepting exponential notation.
* dupe `stellar/amount#StringFromInt64` and `MustParse` into this repo so we can remove the dependency on `stellar/amount` from here (and other places that pull this in) and consolidate the logic for ourselves. 

pulled into https://github.com/keybase/client/pull/13983 and https://github.com/keybase/keybase/pull/2933