### PR TITLE
Add Account.Transactions for /accounts/x/transactions

### DIFF
--- a/account.go
+++ b/account.go
@@ -254,7 +254,7 @@ func AccountSeqno(address AddressStr) (uint64, error) {
 
 // RecentPayments returns the account's recent payments.
 // This is a summary of any recent payment transactions (payment, create_account, or account_merge).
-// It does not contain as much information as RecentTransactions.
+// It does not contain as much information as RecentTransactionsAndOps.
 // It is faster as it is only one request to horizon.
 // cursor is optional.  if specified, it is used for pagination.
 // limit is optional.  if not specified, default is 10.  max limit is 100.
@@ -278,9 +278,9 @@ func (a *Account) RecentPayments(cursor string, limit int) ([]horizon.Payment, e
 	return page.Embedded.Records, nil
 }
 
-// RecentTransactions returns the account's recent transactions, for
+// RecentTransactionsAndOps returns the account's recent transactions, for
 // all types of transactions.
-func (a *Account) RecentTransactions() ([]Transaction, error) {
+func (a *Account) RecentTransactionsAndOps() ([]Transaction, error) {
 	link := Client().URL + "/accounts/" + a.address.String() + "/transactions"
 	var page TransactionsPage
 	err := getDecodeJSONStrict(link+"?order=desc&limit=10", Client().HTTP.Get, &page)

--- a/account_test.go
+++ b/account_test.go
@@ -157,7 +157,7 @@ func TestScenario(t *testing.T) {
 	}
 	t.Logf("bob sent alice 1.0 XLM: %d, %s", ledger, txid)
 
-	aliceTx, err := acctAlice.RecentTransactions()
+	aliceTx, err := acctAlice.RecentTransactionsAndOps()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestScenario(t *testing.T) {
 		// this is unfortunate
 		t.Logf("retrying alice recent transactions after 1s")
 		time.Sleep(1 * time.Second)
-		aliceTx, err = acctAlice.RecentTransactions()
+		aliceTx, err = acctAlice.RecentTransactionsAndOps()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -178,7 +178,7 @@ func TestScenario(t *testing.T) {
 	assertCreateAccount(t, aliceTx[1], "10.0000000", helper.Alice.Address(), helper.Bob.Address())
 	assertCreateAccount(t, aliceTx[2], "10000.0000000", testclient.FriendbotAddress, helper.Alice.Address())
 
-	bobTx, err := acctBob.RecentTransactions()
+	bobTx, err := acctBob.RecentTransactionsAndOps()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Add `Account.Transactions` for paging through `/accounts/💣/transactions`.

The plan is to use `/accounts/💣/transactions` instead of `/accounts/💣/payments`.