### PR TITLE
Resubmit tx to horizon a couple times if seqno error

### DIFF
--- a/account.go
+++ b/account.go
@@ -676,6 +676,15 @@ func Submit(signed string) (ledger int32, txid string, attempt int, err error) {
 				continue
 			}
 
+			// try resubmitting when seqno err
+			hznErr, ok := xerr.(*horizon.Error)
+			if ok {
+				resultCodes, zerr := hznErr.ResultCodes()
+				if zerr == nil && resultCodes.TransactionCode == "tx_bad_seq" {
+					continue
+				}
+			}
+
 			return 0, "", i, errMap(err)
 		}
 


### PR DESCRIPTION
Believe it or not, this does seem to fix a weird issue I've seen with the "dust storm".

I believe it has something to do with transactions not making it into a ledger and then triggering a bad seqno in the next ledger (which seems like a stellar bug to me), but it's hard to get a legitimate reason for these bad seqno errors.  Or perhaps ledger n+1 also doesn't include the transactions that didn't make it into the ledger n.  Something like that is my hunch.

But sending them back to horizon unaltered (Submit is idempotent) seems to work.  We do the same thing for http timeouts.  

I just saw it work in production for 37 transactions.