### PR TITLE
Add amount formatting functions to stellarnet

### DIFF
--- a/format.go
+++ b/format.go
@@ -1,0 +1,114 @@
+package stellarnet
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// FmtRoundingBehavior determines how the formatting functions handle excess precision,
+// either rounding up/down, or truncating.
+type FmtRoundingBehavior int
+
+const (
+	_ FmtRoundingBehavior = iota
+	// Round the amount up or down.  1.234 => 1.23, 1.236 => 1.24
+	Round
+	// Truncate the amount.  1.234 => 1.23, 1.236 => 1.23
+	Truncate
+)
+
+// FmtCurrencyWithCodeSuffix will return a fiat currency amount formatted with
+// its currency code suffix at the end, like "$123.12 CLP"
+func FmtCurrencyWithCodeSuffix(amount string, rounding FmtRoundingBehavior, code, symbol string, postfix bool) (string, error) {
+	pre, err := FmtCurrency(amount, rounding, symbol, postfix)
+	if err != nil {
+		return "", err
+	}
+
+	// some currencies have the same symbol as code (CHF)
+	if postfix && symbol == code {
+		return pre, nil
+	}
+
+	return fmt.Sprintf("%s %s", pre, code), nil
+}
+
+// FmtCurrency returns amount formatted with the currency symbol.
+func FmtCurrency(amount string, rounding FmtRoundingBehavior, symbol string, postfix bool) (string, error) {
+	amountFmt, err := FmtAmount(amount, true, rounding)
+	if err != nil {
+		return "", err
+	}
+
+	if postfix {
+		return fmt.Sprintf("%s %s", amountFmt, symbol), nil
+	}
+
+	return fmt.Sprintf("%s%s", symbol, amountFmt), nil
+}
+
+// FmtAmount formats amount in a clear, precise manner, minimizing the
+// length of the output string when possible.
+func FmtAmount(amount string, precisionTwo bool, rounding FmtRoundingBehavior) (string, error) {
+	if amount == "" {
+		return "", fmt.Errorf("empty amount")
+	}
+	x, err := ParseAmount(amount)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse amount %s: %v", amount, err)
+	}
+	precision := 7
+	if precisionTwo {
+		precision = 2
+	}
+	var s string
+	if rounding == Round {
+		s = x.FloatString(precision)
+	} else {
+		s = x.FloatString(precision + 1)
+		s = s[:len(s)-1]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unable to parse amount %s", amount)
+	}
+	var hasComma bool
+	head := parts[0]
+	if len(head) > 0 {
+		sinceComma := 0
+		var b bytes.Buffer
+		for i := len(head) - 1; i >= 0; i-- {
+			if sinceComma == 3 && head[i] != '-' {
+				b.WriteByte(',')
+				sinceComma = 0
+				hasComma = true
+			}
+			b.WriteByte(head[i])
+			sinceComma++
+		}
+		parts[0] = reverse(b.String())
+	}
+	if parts[1] == "0000000" {
+		// Remove decimal part if it's all zeroes in 7-digit precision.
+		if hasComma {
+			// With the exception of big numbers where we inserted
+			// thousands separator - leave fractional part with two
+			// digits so we can have decimal point, but not all the
+			// distracting 7 zeroes.
+			parts[1] = "00"
+		} else {
+			parts = parts[:1]
+		}
+	}
+
+	return strings.Join(parts, "."), nil
+}
+
+func reverse(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}

--- a/format_test.go
+++ b/format_test.go
@@ -1,0 +1,120 @@
+package stellarnet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fmtTest struct {
+	amount  string
+	precTwo bool
+
+	// "": both 'round' and 'truncate' are expected to return the same result
+	// "round": round the value
+	// "truncate": truncate the value
+	rounding string
+
+	out   string
+	valid bool
+}
+
+var fmtTests = []fmtTest{
+	{amount: "0", precTwo: false, out: "0", valid: true},
+	{amount: "0.00", precTwo: false, out: "0", valid: true},
+	{amount: "0.0000000", precTwo: false, out: "0", valid: true},
+	{amount: "0", precTwo: true, out: "0.00", valid: true},
+	{amount: "0.00", precTwo: true, out: "0.00", valid: true},
+	{amount: "0.0000000", precTwo: true, out: "0.00", valid: true},
+	{amount: "0.123", precTwo: false, out: "0.1230000", valid: true},
+	{amount: "0.123", precTwo: true, out: "0.12", valid: true},
+	{amount: "123", precTwo: false, out: "123", valid: true},
+	{amount: "123", precTwo: true, out: "123.00", valid: true},
+	{amount: "123.456", precTwo: false, out: "123.4560000", valid: true},
+	{amount: "1234.456", precTwo: false, out: "1,234.4560000", valid: true},
+	{amount: "1234.456", precTwo: true, rounding: "round", out: "1,234.46", valid: true},
+	{amount: "1234.456", precTwo: true, rounding: "truncate", out: "1,234.45", valid: true},
+	{amount: "1234.1234567", precTwo: false, out: "1,234.1234567", valid: true},
+	{amount: "123123123.1234567", precTwo: false, out: "123,123,123.1234567", valid: true},
+	{amount: "123123123.1234567", precTwo: true, out: "123,123,123.12", valid: true},
+	{amount: "9123123123.1234567", precTwo: false, out: "9,123,123,123.1234567", valid: true},
+	{amount: "89123123123.1234567", precTwo: false, out: "89,123,123,123.1234567", valid: true},
+	{amount: "456456456123123123.1234567", precTwo: false, out: "456,456,456,123,123,123.1234567", valid: true},
+	{amount: "-0.123", precTwo: false, out: "-0.1230000", valid: true},
+	{amount: "-0.123", precTwo: true, out: "-0.12", valid: true},
+	{amount: "-123", precTwo: false, out: "-123", valid: true},
+	{amount: "-123", precTwo: true, out: "-123.00", valid: true},
+	{amount: "-123.456", precTwo: false, out: "-123.4560000", valid: true},
+	{amount: "-1234.456", precTwo: false, out: "-1,234.4560000", valid: true},
+	{amount: "-1234.456", precTwo: true, rounding: "round", out: "-1,234.46", valid: true},
+	{amount: "-1234.456", precTwo: true, rounding: "truncate", out: "-1,234.45", valid: true},
+	{amount: "-1234.1234567", precTwo: false, out: "-1,234.1234567", valid: true},
+	{amount: "-123123123.1234567", precTwo: false, out: "-123,123,123.1234567", valid: true},
+	{amount: "-123123123.1234567", precTwo: true, out: "-123,123,123.12", valid: true},
+	{amount: "-9123123123.1234567", precTwo: false, out: "-9,123,123,123.1234567", valid: true},
+	{amount: "-89123123123.1234567", precTwo: false, out: "-89,123,123,123.1234567", valid: true},
+	{amount: "-456456456123123123.1234567", precTwo: false, out: "-456,456,456,123,123,123.1234567", valid: true},
+	{amount: "123123", precTwo: true, out: "123,123.00", valid: true},
+	{amount: "123123", precTwo: false, out: "123,123.00", valid: true},
+	// error cases
+	{amount: "", out: "", valid: false},
+	{amount: "garbage", out: "", valid: false},
+	{amount: "3/4", out: "", valid: false},
+	{amount: "1.234e5", out: "", valid: false},
+	{amount: "132E5", out: "", valid: false},
+	{amount: "132.5 3", out: "", valid: false},
+}
+
+func TestFmtAmount(t *testing.T) {
+	for i, test := range fmtTests {
+		switch test.rounding {
+		case "", "round", "truncate":
+		default:
+			t.Fatalf("%v: invalid rounding '%v'", i, test.rounding)
+		}
+		for _, rounding := range []FmtRoundingBehavior{Round, Truncate} {
+			if test.rounding == "round" && rounding == Truncate {
+				continue
+			}
+			if test.rounding == "truncate" && rounding == Round {
+				continue
+			}
+			desc := fmt.Sprintf("amount: %v (2pt prec %v) (rounding %v)", test.amount, test.precTwo, rounding)
+			x, err := FmtAmount(test.amount, test.precTwo, rounding)
+			if test.valid {
+				require.NoError(t, err, "%v => error: %v", desc, err)
+				require.Equal(t, test.out, x, "%v => %q, expected: %q", desc, x, test.out)
+			} else {
+				require.Errorf(t, err, "%v is supposed to be invalid input", desc)
+				require.Equal(t, test.out, x)
+			}
+		}
+	}
+}
+
+type codeTest struct {
+	amount  string
+	code    string
+	symbol  string
+	postfix bool
+
+	out string
+}
+
+var codeTests = []codeTest{
+	{amount: "0", code: "USD", symbol: "$", postfix: false, out: "$0.00 USD"},
+	{amount: "1.234", code: "USD", symbol: "$", postfix: false, out: "$1.23 USD"},
+	{amount: "1.236", code: "USD", symbol: "$", postfix: false, out: "$1.24 USD"},
+	{amount: "13.09", code: "CHF", symbol: "CHF", postfix: true, out: "13.09 CHF"},
+	{amount: "13.09", code: "HUF", symbol: "Ft", postfix: true, out: "13.09 Ft HUF"},
+	{amount: "22.22", code: "AUD", symbol: "$", postfix: false, out: "$22.22 AUD"},
+}
+
+func TestFmtCurrencyWithCodeSuffix(t *testing.T) {
+	for i, test := range codeTests {
+		x, err := FmtCurrencyWithCodeSuffix(test.amount, Round, test.code, test.symbol, test.postfix)
+		require.NoError(t, err, fmt.Sprintf("test %d", i))
+		require.Equal(t, test.out, x)
+	}
+}


### PR DESCRIPTION
I need to use some of these amount formatting functions that we have in `client` on the server, so refactoring them to here so client and server can both use them...