### PR TITLE
Switch deprecated types

### DIFF
--- a/account.go
+++ b/account.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/keypair"
 	snetwork "github.com/stellar/go/network"
+	horizonProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/go/xdr"
 )
@@ -107,7 +108,7 @@ func NetworkPassphrase() string {
 // Account represents a Stellar account.
 type Account struct {
 	address  AddressStr
-	internal *horizon.Account
+	internal *horizonProtocol.Account
 }
 
 // NewAccount makes a new Account item for address.
@@ -160,7 +161,7 @@ func (a *Account) internalNativeBalance() string {
 }
 
 // Balances returns all the balances for an account.
-func (a *Account) Balances() ([]horizon.Balance, error) {
+func (a *Account) Balances() ([]horizonProtocol.Balance, error) {
 	if err := a.load(); err != nil {
 		return nil, err
 	}
@@ -239,7 +240,7 @@ type AccountDetails struct {
 	Seqno                string
 	SubentryCount        int
 	Available            string
-	Balances             []horizon.Balance
+	Balances             []horizonProtocol.Balance
 	InflationDestination string
 }
 
@@ -339,7 +340,7 @@ func (a *Account) RecentPayments(cursor string, limit int) ([]horizon.Payment, e
 // Transactions returns some of the account's transactions.
 // cursor is optional. if specified, it is used for pagination.
 // limit is optional. if not specified, default is 10.  max limit is 100.
-func (a *Account) Transactions(cursor string, limit int) (res []horizon.Transaction, finalPage bool, err error) {
+func (a *Account) Transactions(cursor string, limit int) (res []horizonProtocol.Transaction, finalPage bool, err error) {
 	if limit <= 0 {
 		limit = 10
 	} else if limit > 100 {
@@ -355,7 +356,7 @@ func (a *Account) Transactions(cursor string, limit int) (res []horizon.Transact
 	}
 
 	finalPage = len(page.Embedded.Records) < limit
-	res = make([]horizon.Transaction, len(page.Embedded.Records))
+	res = make([]horizonProtocol.Transaction, len(page.Embedded.Records))
 	for i, record := range page.Embedded.Records {
 		res[i] = record.Transaction
 	}
@@ -413,11 +414,11 @@ func TxPayments(txID string) ([]horizon.Payment, error) {
 	return page.Embedded.Records, nil
 }
 
-// TxDetails gets a horizon.Transaction for txID.
-func TxDetails(txID string) (horizon.Transaction, error) {
+// TxDetails gets a horizonProtocol.Transaction for txID.
+func TxDetails(txID string) (horizonProtocol.Transaction, error) {
 	var embed TransactionEmbed
 	if err := getDecodeJSONStrict(Client().URL+"/transactions/"+txID, Client().HTTP.Get, &embed); err != nil {
-		return horizon.Transaction{}, errMap(err)
+		return horizonProtocol.Transaction{}, errMap(err)
 	}
 	return embed.Transaction, nil
 }
@@ -826,7 +827,7 @@ type SubmitResult struct {
 
 // Submit submits a signed transaction to horizon.
 func Submit(signed string) (res SubmitResult, err error) {
-	var resp horizon.TransactionSuccess
+	var resp horizonProtocol.TransactionSuccess
 	for i := 0; i < submitAttempts; i++ {
 		resp, err = Client().SubmitTransaction(signed)
 		if err != nil {

--- a/account_test.go
+++ b/account_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/keypair"
+	horizonProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/require"
 )
@@ -718,7 +719,7 @@ func TestPathPayments(t *testing.T) {
 	}
 
 	match = false
-	var pathTx horizon.Transaction
+	var pathTx horizonProtocol.Transaction
 	for _, tx := range aliceTx {
 		if tx.ID == txID {
 			match = true

--- a/pages.go
+++ b/pages.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/support/render/hal"
 )
 
 // TransactionEmbed is used to get the Links in addition to
@@ -16,9 +17,9 @@ type TransactionEmbed struct {
 // transactions endpoint.
 type TransactionsPage struct {
 	Links struct {
-		Self horizon.Link `json:"self"`
-		Next horizon.Link `json:"next"`
-		Prev horizon.Link `json:"prev"`
+		Self hal.Link `json:"self"`
+		Next hal.Link `json:"next"`
+		Prev hal.Link `json:"prev"`
 	} `json:"_links"`
 	Embedded struct {
 		Records []TransactionEmbed `json:"records"`
@@ -29,9 +30,9 @@ type TransactionsPage struct {
 // payments endpoint.
 type PaymentsPage struct {
 	Links struct {
-		Self horizon.Link `json:"self"`
-		Next horizon.Link `json:"next"`
-		Prev horizon.Link `json:"prev"`
+		Self hal.Link `json:"self"`
+		Next hal.Link `json:"next"`
+		Prev hal.Link `json:"prev"`
 	} `json:"_links"`
 	Embedded struct {
 		Records []horizon.Payment `json:"records"`
@@ -42,9 +43,9 @@ type PaymentsPage struct {
 // operations endpoint.
 type OperationsPage struct {
 	Links struct {
-		Self horizon.Link `json:"self"`
-		Next horizon.Link `json:"next"`
-		Prev horizon.Link `json:"prev"`
+		Self hal.Link `json:"self"`
+		Next hal.Link `json:"next"`
+		Prev hal.Link `json:"prev"`
 	} `json:"_links"`
 	Embedded struct {
 		Records []Operation `json:"records"`
@@ -88,7 +89,7 @@ type Effect struct {
 // AssetEmbed is a single asset in the AssetsPage.
 type AssetEmbed struct {
 	Links struct {
-		WellKnown horizon.Link `json:"toml"`
+		WellKnown hal.Link `json:"toml"`
 	} `json:"_links"`
 	AssetType   string `json:"asset_type"`
 	AssetCode   string `json:"asset_code"`
@@ -105,9 +106,9 @@ type AssetEmbed struct {
 // AssetsPage is a page of assets.
 type AssetsPage struct {
 	Links struct {
-		Self horizon.Link `json:"self"`
-		Next horizon.Link `json:"next"`
-		Prev horizon.Link `json:"prev"`
+		Self hal.Link `json:"self"`
+		Next hal.Link `json:"next"`
+		Prev hal.Link `json:"prev"`
 	} `json:"_links"`
 	Embedded struct {
 		Records []AssetEmbed `json:"records"`
@@ -180,9 +181,9 @@ func (f FullPath) DestinationAsset() AssetMinimal {
 // PathsPage is used to unmarshal the results from the /paths endpoint.
 type PathsPage struct {
 	Links struct {
-		Self horizon.Link `json:"self"`
-		Next horizon.Link `json:"next"`
-		Prev horizon.Link `json:"prev"`
+		Self hal.Link `json:"self"`
+		Next hal.Link `json:"next"`
+		Prev hal.Link `json:"prev"`
 	} `json:"_links"`
 	Embedded struct {
 		Records []FullPath `json:"records"`

--- a/ping.go
+++ b/ping.go
@@ -5,19 +5,20 @@ import (
 	"fmt"
 
 	"github.com/stellar/go/clients/horizon"
+	horizonProtocol "github.com/stellar/go/protocols/horizon"
 )
 
 // HorizonStatus returns the root status information from the global horizon
 // server.
-func HorizonStatus() (horizon.Root, error) {
+func HorizonStatus() (horizonProtocol.Root, error) {
 	return HorizonStatusForClient(Client())
 }
 
 // HorizonStatusForClient returns the root status information from client's horizon
 // server.
-func HorizonStatusForClient(client *horizon.Client) (horizon.Root, error) {
+func HorizonStatusForClient(client *horizon.Client) (horizonProtocol.Root, error) {
 	if client == nil {
-		return horizon.Root{}, errors.New("nil horizon client")
+		return horizonProtocol.Root{}, errors.New("nil horizon client")
 	}
 
 	return client.Root()


### PR DESCRIPTION
They were all typedefs 👍 

I didn't see any deprecated _function_ use