### PR TITLE
golangci-lint: disable `elseif` check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ linters-settings:
   gocritic:
     disabled-checks:
       - ifElseChain
+      - elseif
 
 linters:
   enable:


### PR DESCRIPTION
By popular demand.